### PR TITLE
no LICENSE file. Link to License section in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,5 @@ Please refer: [README](./README.md)
 
 (taken from [developercertificate.org](https://developercertificate.org/))
 
-See [LICENSE](https://github.com/ni/labview-for-containers/blob/main/LICENSE)
+See [LICENSE](https://github.com/ni/labview-for-containers?tab=readme-ov-file#license)
 for details about how `labview-for-containers` is licensed.


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR resolves the issue that the link to the LICENSE in the CONTRIBUTING.md file is a 404 -- since that file does not exist.  It resolves this problem by changing the link to the [License section at the end of the README.md file](https://github.com/ni/labview-for-containers?tab=readme-ov-file#license).

### Why should this Pull Request be merged?

To ensure that users who want to contribute are able to find and read the licensing terms.  As I think about this now, it's not clear to me that the license terms for the files in this repo are the same as the license terms for the container itself, since this repo does not actually include the installer.  So, maybe you want to fix that, instead of merging this PR.

### What testing has been done?

Clicking link and seeing it go to https://github.com/ni/labview-for-containers?tab=readme-ov-file#license
