### PR TITLE
Document LV_RTE_HEADLESS for default headless mode

### DIFF
--- a/docs/headless-labview.md
+++ b/docs/headless-labview.md
@@ -105,6 +105,11 @@ LabVIEW.exe --headless
 
 This form is primarily useful for advanced users or internal tooling. For general automation and container usage, prefer **LabVIEWCLI with `-Headless`**, which passes this switch for you.
 
+```
+	If you wish to not use the headless argument on every invocation of LabVIEW or LabVIEWCLI, consider setting the environment variable LV_RTE_HEADLESS=1.
+	This environment variable is a global override setting which would make LabVIEW and Run-Time Engine launch in Headless Mode by default.
+```
+
 ## Behavior in Headless Mode
 
 ### UI and Interaction


### PR DESCRIPTION
Add information on using LV_RTE_HEADLESS environment variable.